### PR TITLE
Switch to swizzling IDEMediaLibraryCompletionStrategy

### DIFF
--- a/IgnoreXcodeImageCompletions/IgnoreXcodeImageCompletions.m
+++ b/IgnoreXcodeImageCompletions/IgnoreXcodeImageCompletions.m
@@ -5,20 +5,23 @@
 
 + (void)load {
     NSLog(@"IgnoreXcodeImageCompletions: Loading!");
-    IMP replacement = imp_implementationWithBlock((NSString *)^{ return nil; });
-    Class class = objc_getClass("IDEMediaResourceCompletionItem");
-    Method originalMethod = class_getInstanceMethod(class, @selector(name));
-    const char* encoding = method_getTypeEncoding(originalMethod);
-    SEL newSelector = NSSelectorFromString(@"ixic_setName:");
-    BOOL added = class_addMethod(class, newSelector, replacement, encoding);
 
+    Class class = objc_getClass("IDEMediaLibraryCompletionStrategy");
+    IMP fakeInitializer = imp_implementationWithBlock((id)^{
+        NSLog(@"IgnoreXcodeImageCompletions: Fake initializer was called!");
+        return nil;
+    });
+
+    Method objectInit = class_getInstanceMethod(objc_getClass("NSObject"), @selector(init));
+    const char *encoding = method_getTypeEncoding(objectInit);
+
+    BOOL added = class_addMethod(class, @selector(init), fakeInitializer, encoding);
     if (!added) {
-        NSLog(@"IgnoreXcodeImageCompletions: Failed to add selector");
+        NSLog(@"IgnoreXcodeImageCompletions: Failed to add method :(");
         return;
     }
 
-    Method newMethod = class_getInstanceMethod(class, newSelector);
-    method_exchangeImplementations(originalMethod, newMethod);
+    NSLog(@"IgnoreXcodeImageCompletions: Swizzled selector!");
 }
 
 @end


### PR DESCRIPTION
Swizzling `IDEMediaResourceCompletionItem` and replacing the `name`
selector to return nil _almost_ worked in all cases. Unfortunately in
one codepath the `name` returned from this function was used to
initialize a `NSAttributedString`, resulting in a crash.

This replacement approach goes a level up and creates an initializer for
the `IDEMediaLibraryCompletionStrategy`, which vends the completion items,
and returns nil.

If this failed in theory you could just edit the `IDEKit.xcplugindata`
and delete the `IDEMediaLibraryCompletionStrategy` entry from there,
since that's how Xcode manages plugins, but this is much less
destructive so as long as it works!